### PR TITLE
Alarms Module Version 0.1.4

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -6,7 +6,7 @@
 module "alarm_baseline" {
   count   = var.enable_cis_alarms ? 1 : 0
   source  = "appvia/alarm-baseline/aws"
-  version = "0.1.3"
+  version = "0.1.4"
 
   enable_iam_changes                  = false
   enable_mfa_console_signin_allow_sso = true


### PR DESCRIPTION
Bumping the version of the alarms to v0.1.4, this includes an alarm to indicate is the admin sso role is used
