### PR TITLE
feat/SA-251: latest slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,24 +86,24 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.2 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.64.0 |
-| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | 5.64.0 |
-| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | 5.64.0 |
-| <a name="provider_aws.network"></a> [aws.network](#provider\_aws.network) | 5.64.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws.audit"></a> [aws.audit](#provider\_aws.audit) | 5.65.0 |
+| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | 5.65.0 |
+| <a name="provider_aws.network"></a> [aws.network](#provider\_aws.network) | 5.65.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alarm_baseline"></a> [alarm\_baseline](#module\_alarm\_baseline) | appvia/alarm-baseline/aws | 0.2.0 |
+| <a name="module_alarm_baseline"></a> [alarm\_baseline](#module\_alarm\_baseline) | appvia/alarm-baseline/aws | n/a |
 | <a name="module_cost_management"></a> [cost\_management](#module\_cost\_management) | appvia/oidc/aws//modules/role | 1.3.2 |
-| <a name="module_default_boundary"></a> [default\_boundary](#module\_default\_boundary) | appvia/boundary-stack/aws | 0.1.6 |
+| <a name="module_default_boundary"></a> [default\_boundary](#module\_default\_boundary) | appvia/boundary-stack/aws | 0.1.7 |
 | <a name="module_management_landing_zone"></a> [management\_landing\_zone](#module\_management\_landing\_zone) | appvia/oidc/aws//modules/role | 1.3.2 |
 | <a name="module_management_sso_identity"></a> [management\_sso\_identity](#module\_management\_sso\_identity) | appvia/oidc/aws//modules/role | 1.3.2 |
 | <a name="module_network_inspection_vpc_admin"></a> [network\_inspection\_vpc\_admin](#module\_network\_inspection\_vpc\_admin) | appvia/oidc/aws//modules/role | 1.3.2 |
 | <a name="module_network_transit_gateway_admin"></a> [network\_transit\_gateway\_admin](#module\_network\_transit\_gateway\_admin) | appvia/oidc/aws//modules/role | 1.3.2 |
-| <a name="module_permissive_boundary"></a> [permissive\_boundary](#module\_permissive\_boundary) | appvia/boundary-stack/aws | 0.1.6 |
+| <a name="module_permissive_boundary"></a> [permissive\_boundary](#module\_permissive\_boundary) | appvia/boundary-stack/aws | 0.1.7 |
 | <a name="module_securityhub_notifications"></a> [securityhub\_notifications](#module\_securityhub\_notifications) | appvia/notifications/aws | 0.1.7 |
 
 ## Resources
@@ -148,6 +148,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_accounts_id_to_name"></a> [accounts\_id\_to\_name](#input\_accounts\_id\_to\_name) | A mapping of account id and account name - used by notification lamdba to map an account ID to a human readable name | `map(string)` | `{}` | no |
 | <a name="input_aws_accounts"></a> [aws\_accounts](#input\_aws\_accounts) | Map of AWS account names to their account IDs | <pre>object({<br>    network_account_id      = optional(string, "")<br>    remoteaccess_account_id = optional(string, "")<br>  })</pre> | n/a | yes |
 | <a name="input_aws_support_role_name"></a> [aws\_support\_role\_name](#input\_aws\_support\_role\_name) | Name of the AWS Support role | `string` | `"AWSSupportAccessRole"` | no |
 | <a name="input_breakglass_users"></a> [breakglass\_users](#input\_breakglass\_users) | The number of breakglass users to create | `number` | `2` | no |
@@ -159,7 +160,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 | <a name="input_enable_breakglass"></a> [enable\_breakglass](#input\_enable\_breakglass) | Indicates if we should enable breakglass users and group | `bool` | `false` | no |
 | <a name="input_enable_cis_alarms"></a> [enable\_cis\_alarms](#input\_enable\_cis\_alarms) | Indicates if we should enable CIS alerts | `bool` | `true` | no |
 | <a name="input_enable_securityhub_alarms"></a> [enable\_securityhub\_alarms](#input\_enable\_securityhub\_alarms) | Indicates if we should enable SecurityHub alarms | `bool` | `true` | no |
-| <a name="input_notifications"></a> [notifications](#input\_notifications) | Configuration for the notifications | <pre>object({<br>    email = optional(object({<br>      addresses = list(string)<br>    }), null)<br>    slack = optional(object({<br>      webhook_url = string<br>      channel     = string<br>    }), null)<br>    teams = optional(object({<br>      webhook_url = string<br>    }), null)<br>  })</pre> | <pre>{<br>  "email": {<br>    "addresses": []<br>  },<br>  "slack": null,<br>  "teams": null<br>}</pre> | no |
+| <a name="input_notifications"></a> [notifications](#input\_notifications) | Configuration for the notifications | <pre>object({<br>    email = optional(object({<br>      addresses = list(string)<br>    }), null)<br>    slack = optional(object({<br>      webhook_url = string<br>    }), null)<br>    teams = optional(object({<br>      webhook_url = string<br>    }), null)<br>  })</pre> | <pre>{<br>  "email": {<br>    "addresses": []<br>  },<br>  "slack": null,<br>  "teams": null<br>}</pre> | no |
 | <a name="input_permissive_permissions_boundary_name"></a> [permissive\_permissions\_boundary\_name](#input\_permissive\_permissions\_boundary\_name) | Name of the permissive IAM policy to use as a permissions boundary | `string` | `"lza-permissive-boundary"` | no |
 | <a name="input_repositories"></a> [repositories](#input\_repositories) | List of repository locations for the pipelines | <pre>object({<br>    accelerator = optional(object({<br>      url       = string<br>      role_name = optional(string, "lza-accelerator")<br>    }), null)<br>    connectivity = optional(object({<br>      url       = string<br>      role_name = optional(string, "lza-connectivity")<br>    }), null)<br>    cost_management = optional(object({<br>      url       = string<br>      role_name = optional(string, "lza-cost-management")<br>    }), null)<br>    firewall = optional(object({<br>      url       = string<br>      role_name = optional(string, "lza-firewall")<br>    }), null)<br>    identity = optional(object({<br>      url       = string<br>      role_name = optional(string, "lza-identity")<br>    }), null)<br>  })</pre> | `{}` | no |
 | <a name="input_scm_name"></a> [scm\_name](#input\_scm\_name) | Name of the source control management system (github or gitlab) | `string` | `"github"` | no |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alarm_baseline"></a> [alarm\_baseline](#module\_alarm\_baseline) | appvia/alarm-baseline/aws | n/a |
+| <a name="module_alarm_baseline"></a> [alarm\_baseline](#module\_alarm\_baseline) | appvia/alarm-baseline/aws | 0.2.4 |
 | <a name="module_cost_management"></a> [cost\_management](#module\_cost\_management) | appvia/oidc/aws//modules/role | 1.3.2 |
 | <a name="module_default_boundary"></a> [default\_boundary](#module\_default\_boundary) | appvia/boundary-stack/aws | 0.1.7 |
 | <a name="module_management_landing_zone"></a> [management\_landing\_zone](#module\_management\_landing\_zone) | appvia/oidc/aws//modules/role | 1.3.2 |
@@ -104,7 +104,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 | <a name="module_network_inspection_vpc_admin"></a> [network\_inspection\_vpc\_admin](#module\_network\_inspection\_vpc\_admin) | appvia/oidc/aws//modules/role | 1.3.2 |
 | <a name="module_network_transit_gateway_admin"></a> [network\_transit\_gateway\_admin](#module\_network\_transit\_gateway\_admin) | appvia/oidc/aws//modules/role | 1.3.2 |
 | <a name="module_permissive_boundary"></a> [permissive\_boundary](#module\_permissive\_boundary) | appvia/boundary-stack/aws | 0.1.7 |
-| <a name="module_securityhub_notifications"></a> [securityhub\_notifications](#module\_securityhub\_notifications) | appvia/notifications/aws | 0.1.7 |
+| <a name="module_securityhub_notifications"></a> [securityhub\_notifications](#module\_securityhub\_notifications) | appvia/notifications/aws | 1.0.3 |
 
 ## Resources
 

--- a/locals.tf
+++ b/locals.tf
@@ -67,9 +67,7 @@ locals {
 
   ## The configuration for the slack notification 
   slack = local.enable_slack_notifications ? {
-    channel     = var.notifications.slack.channel
     lambda_name = "lza-ca-notifications-slack"
-    username    = ":aws: Security Notifications"
     webhook_url = var.notifications.slack.webhook_url
   } : null
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 
 ## Provision the CIS AWS Foundations CloudWatch Alarms
 module "alarm_baseline" {
-  count   = var.enable_cis_alarms ? 1 : 0
-  source  = "appvia/alarm-baseline/aws"
-  version = "0.2.0"
+  count  = var.enable_cis_alarms ? 1 : 0
+  source = "appvia/alarm-baseline/aws"
+  # version = "0.2.3"
 
   create_sns_topic                    = true
   enable_iam_changes                  = false
@@ -11,6 +11,8 @@ module "alarm_baseline" {
   enable_organizations_changes        = false
   notification                        = local.notifications
   tags                                = var.tags
+  # accounts_id_to_name                 = var.accounts_id_to_name
+  # cloudwatch_log_group_retention      = 3
 
   providers = {
     aws = aws.management

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 
 ## Provision the CIS AWS Foundations CloudWatch Alarms
 module "alarm_baseline" {
-  count  = var.enable_cis_alarms ? 1 : 0
-  source = "appvia/alarm-baseline/aws"
-  # version = "0.2.3"
+  count   = var.enable_cis_alarms ? 1 : 0
+  source  = "appvia/alarm-baseline/aws"
+  version = "0.2.4"
 
   create_sns_topic                    = true
   enable_iam_changes                  = false
@@ -11,8 +11,8 @@ module "alarm_baseline" {
   enable_organizations_changes        = false
   notification                        = local.notifications
   tags                                = var.tags
-  # accounts_id_to_name                 = var.accounts_id_to_name
-  # cloudwatch_log_group_retention      = 3
+  accounts_id_to_name                 = var.accounts_id_to_name
+  cloudwatch_log_group_retention      = 3
 
   providers = {
     aws = aws.management

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -53,13 +53,20 @@ module "securityhub_notifications" {
   count   = var.enable_securityhub_alarms ? 1 : 0
   source  = "appvia/notifications/aws"
   version = "0.1.7"
+  # version = "1.0.3"
 
   allowed_aws_services = ["events.amazonaws.com", "lambda.amazonaws.com"]
   create_sns_topic     = true
-  email                = local.email
-  slack                = local.slack
   sns_topic_name       = var.securityhub_sns_topic_name
-  tags                 = var.tags
+
+  email = local.email
+
+  # cloudwatch_log_group_retention = 3
+  # enable_slack         = true
+  # slack                = local.slack
+
+  tags = var.tags
+  # accounts_id_to_name  = var.accounts_id_to_name
 
   providers = {
     aws = aws.audit

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -52,8 +52,7 @@ data "archive_file" "securityhub_lambda_package" {
 module "securityhub_notifications" {
   count   = var.enable_securityhub_alarms ? 1 : 0
   source  = "appvia/notifications/aws"
-  version = "0.1.7"
-  # version = "1.0.3"
+  version = "1.0.3"
 
   allowed_aws_services = ["events.amazonaws.com", "lambda.amazonaws.com"]
   create_sns_topic     = true
@@ -61,12 +60,12 @@ module "securityhub_notifications" {
 
   email = local.email
 
-  # cloudwatch_log_group_retention = 3
-  # enable_slack         = true
-  # slack                = local.slack
+  cloudwatch_log_group_retention = 3
+  enable_slack                   = true
+  slack                          = local.slack
 
-  tags = var.tags
-  # accounts_id_to_name  = var.accounts_id_to_name
+  tags                = var.tags
+  accounts_id_to_name = var.accounts_id_to_name
 
   providers = {
     aws = aws.audit

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,6 @@ variable "notifications" {
     }), null)
     slack = optional(object({
       webhook_url = string
-      channel     = string
     }), null)
     teams = optional(object({
       webhook_url = string
@@ -178,4 +177,10 @@ variable "repositories" {
 variable "tags" {
   description = "Tags to apply to all resources"
   type        = map(string)
+}
+
+variable "accounts_id_to_name" {
+  description = "A mapping of account id and account name - used by notification lamdba to map an account ID to a human readable name"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
* Alarms - uses the new baseline for alarms module which itself uses the latest notifications modules; deploys into root account
* Security Hub - uses the latest notifications directly - hard coded cloudwatch retention days. Deploys into Audit account

Both utilise a new module variable for mapping account ids to names; both alarms and security hub findings will come from any account in LZA, so using the same list of account mappings.
