### PR TITLE
feat: add policies to allow creation of resources related to ssosync

### DIFF
--- a/management.tf
+++ b/management.tf
@@ -193,6 +193,9 @@ module "management_sso_identity" {
     "arn:aws:iam::aws:policy/ReadOnlyAccess",
     "arn:aws:iam::aws:policy/IAMFullAccess",
     "arn:aws:iam::aws:policy/Lambda_FullAccess",
+    "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser",
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+    "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
   ]
 
   read_write_inline_policies = {

--- a/management.tf
+++ b/management.tf
@@ -192,6 +192,7 @@ module "management_sso_identity" {
     "arn:aws:iam::aws:policy/AWSSSOReadOnly",
     "arn:aws:iam::aws:policy/ReadOnlyAccess",
     "arn:aws:iam::aws:policy/IAMFullAccess",
+    "arn:aws:iam::aws:policy/Lambda_FullAccess",
   ]
 
   read_write_inline_policies = {
@@ -203,7 +204,6 @@ module "management_sso_identity" {
             "sso:DeleteInlinePolicyFromPermissionSet",
             "sso:PutInlinePolicyToPermissionSet",
             "secretsmanager:GetSecretValue",
-            
           ]
           Effect   = "Allow"
           Resource = "*"


### PR DESCRIPTION
Adds:
- "arn:aws:iam::aws:policy/Lambda_FullAccess",
-  "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser",
-  "arn:aws:iam::aws:policy/AmazonS3FullAccess",
-  "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"

 to the identity read_write role so that terraform can create a lambda function + associated resources.